### PR TITLE
Fix parsing telemetry data crash due to unexpected undefined values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pubg-typescript-api",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "TypeScript wrapper on the official PUBG API",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/entities/telemetry/events/playerAttack.ts
+++ b/src/entities/telemetry/events/playerAttack.ts
@@ -12,7 +12,7 @@ export class PlayerAttack extends TelemetryEvent {
   private _attacker: Character;
   private _attackType: string;
   private _weapon: Item;
-  private _vehicle: Vehicle;
+  private _vehicle?: Vehicle;
 
   constructor(event: ILogPlayerAttack) {
     super(event);
@@ -20,7 +20,9 @@ export class PlayerAttack extends TelemetryEvent {
     this._attacker = new Character(event.attacker);
     this._attackType = event.attackType;
     this._weapon = new Item(event.weapon);
-    this._vehicle = new Vehicle(event.vehicle);
+    if (event.vehicle) {
+      this._vehicle = new Vehicle(event.vehicle);
+    }
   }
 
   get attackId(): number {
@@ -39,7 +41,7 @@ export class PlayerAttack extends TelemetryEvent {
     return this._weapon;
   }
 
-  get vehicle(): Vehicle {
+  get vehicle(): Vehicle | undefined {
     return this._vehicle;
   }
 }

--- a/src/entities/telemetry/events/playerTakeDamage.ts
+++ b/src/entities/telemetry/events/playerTakeDamage.ts
@@ -7,7 +7,7 @@ import { TelemetryEvent } from './telemetryEvent';
 
 export class PlayerTakeDamage extends TelemetryEvent {
   private _attackId: number;
-  private _attacker: Character;
+  private _attacker?: Character;
   private _victim: Character;
   private _damageTypeCategory: string;
   private _damageCauserName: string;
@@ -17,19 +17,21 @@ export class PlayerTakeDamage extends TelemetryEvent {
   constructor(event: ILogPlayerTakeDamage) {
     super(event);
     this._attackId = event.attackId;
-    this._attacker = new Character(event.attacker);
     this._victim = new Character(event.victim);
     this._damageTypeCategory = event.damageTypeCategory;
     this._damageCauserName = event.damageCauserName;
     this._damageReason = event.damageReason;
     this._damage = event.damage;
+    if (event.attacker) {
+      this._attacker = new Character(event.attacker);
+    }
   }
 
   get attackId(): number {
     return this._attackId;
   }
 
-  get attacker(): Character {
+  get attacker(): Character | undefined {
     return this._attacker;
   }
 

--- a/src/entities/telemetry/telemetry.spec.ts
+++ b/src/entities/telemetry/telemetry.spec.ts
@@ -1240,10 +1240,11 @@ describe('Telemetry entity', () => {
     expect(weapon.subCategory).to.eq('Main');
 
     const vehicle = event.vehicle;
-    expect(vehicle.vehicleType).to.eq('');
-    expect(vehicle.vehicleId).to.eq('');
-    expect(vehicle.healthPercent).to.eq(0);
-    expect(vehicle.feulPercent).to.eq(0);
+    expect(vehicle).to.not.be.undefined;
+    expect(vehicle!.vehicleType).to.eq('');
+    expect(vehicle!.vehicleId).to.eq('');
+    expect(vehicle!.healthPercent).to.eq(0);
+    expect(vehicle!.feulPercent).to.eq(0);
   });
 
   it('should parse player create events', () => {
@@ -1395,14 +1396,15 @@ describe('Telemetry entity', () => {
     expect(event.damageReason).to.eq('HeadShot');
 
     const attacker = event.attacker;
-    expect(attacker.accountId).to.eq('account.bdfbbf10e33f4e33bd5967fa6a8af35d');
-    expect(attacker.health).to.eq(0);
-    expect(attacker.location.x).to.eq(0);
-    expect(attacker.location.y).to.eq(0);
-    expect(attacker.location.z).to.eq(0);
-    expect(attacker.name).to.eq('sami_70');
-    expect(attacker.ranking).to.eq(0);
-    expect(attacker.teamId).to.eq(44);
+    expect(attacker).to.not.be.undefined;
+    expect(attacker!.accountId).to.eq('account.bdfbbf10e33f4e33bd5967fa6a8af35d');
+    expect(attacker!.health).to.eq(0);
+    expect(attacker!.location.x).to.eq(0);
+    expect(attacker!.location.y).to.eq(0);
+    expect(attacker!.location.z).to.eq(0);
+    expect(attacker!.name).to.eq('sami_70');
+    expect(attacker!.ranking).to.eq(0);
+    expect(attacker!.teamId).to.eq(44);
 
     const victim = event.victim;
     expect(victim.accountId).to.eq('account.54b42bdadae640058f931a1b1fb66793');

--- a/src/interfaces/telemetry.ts
+++ b/src/interfaces/telemetry.ts
@@ -93,7 +93,7 @@ export interface ILogPlayerAttack extends ITelemetryEvent {
   attacker: ICharacter;
   attackType: string;
   weapon: IItem;
-  vehicle: IVehicle;
+  vehicle?: IVehicle;
 }
 
 export interface ILogItemPickup extends ITelemetryEvent {
@@ -156,7 +156,7 @@ export interface ILogVehicleLeave extends ITelemetryEvent {
 export interface ILogPlayerTakeDamage extends ITelemetryEvent {
   _T: 'LogPlayerTakeDamage';
   attackId: number;
-  attacker: ICharacter;
+  attacker?: ICharacter;
   victim: ICharacter;
   damageTypeCategory: string;
   damageReason: string;


### PR DESCRIPTION
PlayerAttack: vehicle can be null
PlayerTakeDamage: attacker can be null